### PR TITLE
Use protobuf reflection for serialization

### DIFF
--- a/tools/mc2bq/pkg/export/v1.go
+++ b/tools/mc2bq/pkg/export/v1.go
@@ -36,7 +36,7 @@ func (mc *MCv1) AssetSource(ctx context.Context, pal mcutil.ProjectAndLocation) 
 		Parent:   pal.String(),
 		PageSize: 1000,
 	})
-	r := newObjectReader[migrationcenterpb.Asset](it, "asset", mc.schema.AssetTable)
+	r := newObjectReader[*migrationcenterpb.Asset](it, "asset", mc.schema.AssetTable)
 	src := newMigrationCenterLoadSource(r)
 	return &struct {
 		bigquery.LoadSource
@@ -49,7 +49,7 @@ func (mc *MCv1) GroupSource(ctx context.Context, pal mcutil.ProjectAndLocation) 
 		Parent:   pal.String(),
 		PageSize: 1000,
 	})
-	r := newObjectReader[migrationcenterpb.Group](it, "asset", mc.schema.GroupTable)
+	r := newObjectReader[*migrationcenterpb.Group](it, "group", mc.schema.GroupTable)
 	src := newMigrationCenterLoadSource(r)
 	return &struct {
 		bigquery.LoadSource
@@ -62,7 +62,7 @@ func (mc *MCv1) PreferenceSetSource(ctx context.Context, pal mcutil.ProjectAndLo
 		Parent:   pal.String(),
 		PageSize: 1000,
 	})
-	r := newObjectReader[migrationcenterpb.PreferenceSet](it, "asset", mc.schema.PreferenceSetTable)
+	r := newObjectReader[*migrationcenterpb.PreferenceSet](it, "preference_set", mc.schema.PreferenceSetTable)
 	src := newMigrationCenterLoadSource(r)
 	return &struct {
 		bigquery.LoadSource

--- a/tools/mc2bq/pkg/schema/migrationcenter_v1_latest.schema.json
+++ b/tools/mc2bq/pkg/schema/migrationcenter_v1_latest.schema.json
@@ -1,1449 +1,1419 @@
-{"asset_table":[
- {
-  "name": "name",
-  "type": "STRING",
-  "mode": "NULLABLE"
- },
- {
-  "name": "create_time",
-  "type": "TIMESTAMP",
-  "mode": "NULLABLE"
- },
- {
-  "name": "update_time",
-  "type": "TIMESTAMP",
-  "mode": "NULLABLE"
- },
- {
-  "name": "labels",
-  "type": "RECORD",
-  "mode": "REPEATED",
-  "fields": [
-   {
-    "name": "key",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "value",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   }
-  ]
- },
- {
-  "name": "attributes",
-  "type": "RECORD",
-  "mode": "REPEATED",
-  "fields": [
-   {
-    "name": "key",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "value",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   }
-  ]
- },
- {
-  "name": "machine_details",
-  "type": "RECORD",
-  "mode": "NULLABLE",
-  "fields": [
-   {
-    "name": "uuid",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "machine_name",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "create_time",
-    "type": "TIMESTAMP",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "core_count",
-    "type": "INTEGER",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "memory_mb",
-    "type": "INTEGER",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "power_state",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "architecture",
-    "type": "RECORD",
-    "mode": "NULLABLE",
-    "fields": [
-     {
-      "name": "cpu_architecture",
+{
+  "asset_table": [
+    {
+      "name": "name",
       "type": "STRING",
       "mode": "NULLABLE"
-     },
-     {
-      "name": "cpu_name",
-      "type": "STRING",
+    },
+    {
+      "name": "create_time",
+      "type": "TIMESTAMP",
       "mode": "NULLABLE"
-     },
-     {
-      "name": "vendor",
-      "type": "STRING",
+    },
+    {
+      "name": "update_time",
+      "type": "TIMESTAMP",
       "mode": "NULLABLE"
-     },
-     {
-      "name": "cpu_thread_count",
-      "type": "INTEGER",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "cpu_socket_count",
-      "type": "INTEGER",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "bios",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "bios_name",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "id",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "manufacturer",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "version",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "release_date",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "year",
-          "type": "INTEGER",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "month",
-          "type": "INTEGER",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "day",
-          "type": "INTEGER",
-          "mode": "NULLABLE"
-         }
-        ]
-       },
-       {
-        "name": "smbios_uuid",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       }
-      ]
-     },
-     {
-      "name": "firmware_type",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "hyperthreading",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     }
-    ]
-   },
-   {
-    "name": "guest_os",
-    "type": "RECORD",
-    "mode": "NULLABLE",
-    "fields": [
-     {
-      "name": "os_name",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "family",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "version",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "config",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "issue",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "fstab",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "entries",
-          "type": "RECORD",
-          "mode": "REPEATED",
-          "fields": [
-           {
-            "name": "spec",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "file",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "vfstype",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "mntops",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "freq",
-            "type": "INTEGER",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "passno",
-            "type": "INTEGER",
-            "mode": "NULLABLE"
-           }
-          ]
-         }
-        ]
-       },
-       {
-        "name": "hosts",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "entries",
-          "type": "RECORD",
-          "mode": "REPEATED",
-          "fields": [
-           {
-            "name": "ip",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "host_names",
-            "type": "STRING",
-            "mode": "REPEATED"
-           }
-          ]
-         }
-        ]
-       },
-       {
-        "name": "nfs_exports",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "entries",
-          "type": "RECORD",
-          "mode": "REPEATED",
-          "fields": [
-           {
-            "name": "export_directory",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "hosts",
-            "type": "STRING",
-            "mode": "REPEATED"
-           }
-          ]
-         }
-        ]
-       },
-       {
-        "name": "selinux_mode",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       }
-      ]
-     },
-     {
-      "name": "runtime",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "services",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "entries",
-          "type": "RECORD",
-          "mode": "REPEATED",
-          "fields": [
-           {
-            "name": "service_name",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "state",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "start_mode",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "exe_path",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "cmdline",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "pid",
-            "type": "INTEGER",
-            "mode": "NULLABLE"
-           }
-          ]
-         }
-        ]
-       },
-       {
-        "name": "processes",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "entries",
-          "type": "RECORD",
-          "mode": "REPEATED",
-          "fields": [
-           {
-            "name": "pid",
-            "type": "INTEGER",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "exe_path",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "cmdline",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "user",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "attributes",
-            "type": "RECORD",
-            "mode": "REPEATED",
-            "fields": [
-             {
-              "name": "key",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "value",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             }
-            ]
-           }
-          ]
-         }
-        ]
-       },
-       {
-        "name": "network",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "scan_time",
-          "type": "TIMESTAMP",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "connections",
-          "type": "RECORD",
-          "mode": "NULLABLE",
-          "fields": [
-           {
-            "name": "entries",
-            "type": "RECORD",
-            "mode": "REPEATED",
-            "fields": [
-             {
-              "name": "protocol",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "local_ip_address",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "local_port",
-              "type": "INTEGER",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "remote_ip_address",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "remote_port",
-              "type": "INTEGER",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "state",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "pid",
-              "type": "INTEGER",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "process_name",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             }
-            ]
-           }
-          ]
-         }
-        ]
-       },
-       {
-        "name": "last_boot_time",
-        "type": "TIMESTAMP",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "domain",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "machine_name",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "installed_apps",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "entries",
-          "type": "RECORD",
-          "mode": "REPEATED",
-          "fields": [
-           {
-            "name": "application_name",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "vendor",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "install_time",
-            "type": "TIMESTAMP",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "path",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "version",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           }
-          ]
-         }
-        ]
-       },
-       {
-        "name": "open_file_list",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "entries",
-          "type": "RECORD",
-          "mode": "REPEATED",
-          "fields": [
-           {
-            "name": "command",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "user",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "file_type",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "file_path",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           }
-          ]
-         }
-        ]
-       }
-      ]
-     }
-    ]
-   },
-   {
-    "name": "network",
-    "type": "RECORD",
-    "mode": "NULLABLE",
-    "fields": [
-     {
-      "name": "primary_ip_address",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "public_ip_address",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "primary_mac_address",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "adapters",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "entries",
-        "type": "RECORD",
-        "mode": "REPEATED",
-        "fields": [
-         {
-          "name": "adapter_type",
-          "type": "STRING",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "mac_address",
-          "type": "STRING",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "addresses",
-          "type": "RECORD",
-          "mode": "NULLABLE",
-          "fields": [
-           {
-            "name": "entries",
-            "type": "RECORD",
-            "mode": "REPEATED",
-            "fields": [
-             {
-              "name": "ip_address",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "subnet_mask",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "bcast",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "fqdn",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "assignment",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             }
-            ]
-           }
-          ]
-         }
-        ]
-       }
-      ]
-     }
-    ]
-   },
-   {
-    "name": "disks",
-    "type": "RECORD",
-    "mode": "NULLABLE",
-    "fields": [
-     {
-      "name": "total_capacity_bytes",
-      "type": "INTEGER",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "total_free_bytes",
-      "type": "INTEGER",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "disks",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "entries",
-        "type": "RECORD",
-        "mode": "REPEATED",
-        "fields": [
-         {
-          "name": "capacity_bytes",
-          "type": "INTEGER",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "free_bytes",
-          "type": "INTEGER",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "disk_label",
-          "type": "STRING",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "disk_label_type",
-          "type": "STRING",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "interface_type",
-          "type": "STRING",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "partitions",
-          "type": "RECORD",
-          "mode": "NULLABLE",
-          "fields": [
-           {
-            "name": "entries",
-            "type": "RECORD",
-            "mode": "REPEATED",
-            "fields": [
-             {
-              "name": "type",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "file_system",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "mount_point",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "capacity_bytes",
-              "type": "INTEGER",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "free_bytes",
-              "type": "INTEGER",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "uuid",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             }
-            ]
-           }
-          ]
-         },
-         {
-          "name": "hw_address",
-          "type": "STRING",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "vmware",
-          "type": "RECORD",
-          "mode": "NULLABLE",
-          "fields": [
-           {
-            "name": "backing_type",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "shared",
-            "type": "BOOLEAN",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "vmdk_mode",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "rdm_compatibility",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           }
-          ]
-         }
-        ]
-       }
-      ]
-     }
-    ]
-   },
-   {
-    "name": "platform",
-    "type": "RECORD",
-    "mode": "NULLABLE",
-    "fields": [
-     {
-      "name": "vmware_details",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "vcenter_version",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "esx_version",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "osid",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "vcenter_folder",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "vcenter_uri",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "vcenter_vm_id",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       }
-      ]
-     },
-     {
-      "name": "aws_ec2_details",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "machine_type_label",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "location",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       }
-      ]
-     },
-     {
-      "name": "azure_vm_details",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "machine_type_label",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "location",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "provisioning_state",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       }
-      ]
-     },
-     {
-      "name": "generic_details",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "location",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       }
-      ]
-     },
-     {
-      "name": "physical_details",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "location",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       }
-      ]
-     }
-    ]
-   }
-  ]
- },
- {
-  "name": "insight_list",
-  "type": "RECORD",
-  "mode": "NULLABLE",
-  "fields": [
-   {
-    "name": "insights",
-    "type": "RECORD",
-    "mode": "REPEATED",
-    "fields": [
-     {
-      "name": "migration_insight",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "fit",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "fit_level",
-          "type": "STRING",
-          "mode": "NULLABLE"
-         }
-        ]
-       },
-       {
-        "name": "compute_engine_target",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "shape",
-          "type": "RECORD",
-          "mode": "NULLABLE",
-          "fields": [
-           {
-            "name": "memory_mb",
-            "type": "INTEGER",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "physical_core_count",
-            "type": "INTEGER",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "logical_core_count",
-            "type": "INTEGER",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "series",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "machine_type",
-            "type": "STRING",
-            "mode": "NULLABLE"
-           },
-           {
-            "name": "storage",
-            "type": "RECORD",
-            "mode": "REPEATED",
-            "fields": [
-             {
-              "name": "type",
-              "type": "STRING",
-              "mode": "NULLABLE"
-             },
-             {
-              "name": "size_gb",
-              "type": "INTEGER",
-              "mode": "NULLABLE"
-             }
-            ]
-           }
-          ]
-         }
-        ]
-       }
-      ]
-     },
-     {
-      "name": "generic_insight",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "message_id",
-        "type": "INTEGER",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "default_message",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "additional_information",
-        "type": "STRING",
-        "mode": "REPEATED"
-       }
-      ]
-     },
-     {
-      "name": "software_insight",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "detected_software",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "software_name",
-          "type": "STRING",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "software_family",
-          "type": "STRING",
-          "mode": "NULLABLE"
-         }
-        ]
-       }
-      ]
-     }
-    ]
-   },
-   {
-    "name": "update_time",
-    "type": "TIMESTAMP",
-    "mode": "NULLABLE"
-   }
-  ]
- },
- {
-  "name": "performance_data",
-  "type": "RECORD",
-  "mode": "NULLABLE",
-  "fields": [
-   {
-    "name": "daily_resource_usage_aggregations",
-    "type": "RECORD",
-    "mode": "REPEATED",
-    "fields": [
-     {
-      "name": "date",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "year",
-        "type": "INTEGER",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "month",
-        "type": "INTEGER",
-        "mode": "NULLABLE"
-       },
-       {
-        "name": "day",
-        "type": "INTEGER",
-        "mode": "NULLABLE"
-       }
-      ]
-     },
-     {
-      "name": "cpu",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "utilization_percentage",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "average",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "median",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "nintey_fifth_percentile",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "peak",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         }
-        ]
-       }
-      ]
-     },
-     {
-      "name": "memory",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "utilization_percentage",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "average",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "median",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "nintey_fifth_percentile",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "peak",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         }
-        ]
-       }
-      ]
-     },
-     {
-      "name": "network",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "ingress_bps",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "average",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "median",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "nintey_fifth_percentile",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "peak",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         }
-        ]
-       },
-       {
-        "name": "egress_bps",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "average",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "median",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "nintey_fifth_percentile",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "peak",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         }
-        ]
-       }
-      ]
-     },
-     {
-      "name": "disk",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "iops",
-        "type": "RECORD",
-        "mode": "NULLABLE",
-        "fields": [
-         {
-          "name": "average",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "median",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "nintey_fifth_percentile",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         },
-         {
-          "name": "peak",
-          "type": "FLOAT",
-          "mode": "NULLABLE"
-         }
-        ]
-       }
-      ]
-     }
-    ]
-   }
-  ]
- },
- {
-  "name": "sources",
-  "type": "STRING",
-  "mode": "REPEATED"
- },
- {
-  "name": "assigned_groups",
-  "type": "STRING",
-  "mode": "REPEATED"
- }
-],"group_table":[
- {
-  "name": "name",
-  "type": "STRING",
-  "mode": "NULLABLE"
- },
- {
-  "name": "create_time",
-  "type": "TIMESTAMP",
-  "mode": "NULLABLE"
- },
- {
-  "name": "update_time",
-  "type": "TIMESTAMP",
-  "mode": "NULLABLE"
- },
- {
-  "name": "labels",
-  "type": "RECORD",
-  "mode": "REPEATED",
-  "fields": [
-   {
-    "name": "key",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "value",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   }
-  ]
- },
- {
-  "name": "display_name",
-  "type": "STRING",
-  "mode": "NULLABLE"
- },
- {
-  "name": "description",
-  "type": "STRING",
-  "mode": "NULLABLE"
- }
-],"preference_set_table":[
- {
-  "name": "name",
-  "type": "STRING",
-  "mode": "NULLABLE"
- },
- {
-  "name": "create_time",
-  "type": "TIMESTAMP",
-  "mode": "NULLABLE"
- },
- {
-  "name": "update_time",
-  "type": "TIMESTAMP",
-  "mode": "NULLABLE"
- },
- {
-  "name": "display_name",
-  "type": "STRING",
-  "mode": "NULLABLE"
- },
- {
-  "name": "description",
-  "type": "STRING",
-  "mode": "NULLABLE"
- },
- {
-  "name": "virtual_machine_preferences",
-  "type": "RECORD",
-  "mode": "NULLABLE",
-  "fields": [
-   {
-    "name": "business_goal",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "target_product",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "region_preferences",
-    "type": "RECORD",
-    "mode": "NULLABLE",
-    "fields": [
-     {
-      "name": "preferred_regions",
-      "type": "STRING",
-      "mode": "REPEATED"
-     }
-    ]
-   },
-   {
-    "name": "commitment_plan",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "sizing_optimization_strategy",
-    "type": "STRING",
-    "mode": "NULLABLE"
-   },
-   {
-    "name": "compute_engine_preferences",
-    "type": "RECORD",
-    "mode": "NULLABLE",
-    "fields": [
-     {
-      "name": "persistent_disk_type",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "machine_preferences",
-      "type": "RECORD",
-      "mode": "NULLABLE",
-      "fields": [
-       {
-        "name": "allowed_machine_series",
-        "type": "RECORD",
-        "mode": "REPEATED",
-        "fields": [
-         {
-          "name": "code",
-          "type": "STRING",
-          "mode": "NULLABLE"
-         }
-        ]
-       }
-      ]
-     },
-     {
-      "name": "license_type",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     }
-    ]
-   },
-   {
-    "name": "vmware_engine_preferences",
-    "type": "RECORD",
-    "mode": "NULLABLE",
-    "fields": [
-     {
-      "name": "cpu_overcommit_ratio",
-      "type": "FLOAT",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "memory_overcommit_ratio",
-      "type": "FLOAT",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "storage_deduplication_compression_ratio",
-      "type": "FLOAT",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "commitment_plan",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     }
-    ]
-   },
-   {
-    "name": "sole_tenancy_preferences",
-    "type": "RECORD",
-    "mode": "NULLABLE",
-    "fields": [
-     {
-      "name": "cpu_overcommit_ratio",
-      "type": "FLOAT",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "host_maintenance_policy",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "commitment_plan",
-      "type": "STRING",
-      "mode": "NULLABLE"
-     },
-     {
-      "name": "node_types",
+    },
+    {
+      "name": "labels",
       "type": "RECORD",
       "mode": "REPEATED",
       "fields": [
-       {
-        "name": "node_name",
-        "type": "STRING",
-        "mode": "NULLABLE"
-       }
+        {
+          "name": "key",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "value",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        }
       ]
-     }
-    ]
-   }
+    },
+    {
+      "name": "attributes",
+      "type": "RECORD",
+      "mode": "REPEATED",
+      "fields": [
+        {
+          "name": "key",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "value",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        }
+      ]
+    },
+    {
+      "name": "machine_details",
+      "type": "RECORD",
+      "mode": "NULLABLE",
+      "fields": [
+        {
+          "name": "uuid",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "machine_name",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "create_time",
+          "type": "TIMESTAMP",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "core_count",
+          "type": "INTEGER",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "memory_mb",
+          "type": "INTEGER",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "power_state",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "architecture",
+          "type": "RECORD",
+          "mode": "NULLABLE",
+          "fields": [
+            {
+              "name": "cpu_architecture",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "cpu_name",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "vendor",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "cpu_thread_count",
+              "type": "INTEGER",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "cpu_socket_count",
+              "type": "INTEGER",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "bios",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "bios_name",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "id",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "manufacturer",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "version",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "release_date",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "year",
+                      "type": "INTEGER",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "month",
+                      "type": "INTEGER",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "day",
+                      "type": "INTEGER",
+                      "mode": "NULLABLE"
+                    }
+                  ]
+                },
+                {
+                  "name": "smbios_uuid",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                }
+              ]
+            },
+            {
+              "name": "firmware_type",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "hyperthreading",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            }
+          ]
+        },
+        {
+          "name": "guest_os",
+          "type": "RECORD",
+          "mode": "NULLABLE",
+          "fields": [
+            {
+              "name": "os_name",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "family",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "version",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "config",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "issue",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "fstab",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "entries",
+                      "type": "RECORD",
+                      "mode": "REPEATED",
+                      "fields": [
+                        {
+                          "name": "spec",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "file",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "vfstype",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "mntops",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "freq",
+                          "type": "INTEGER",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "passno",
+                          "type": "INTEGER",
+                          "mode": "NULLABLE"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "hosts",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "entries",
+                      "type": "RECORD",
+                      "mode": "REPEATED",
+                      "fields": [
+                        {
+                          "name": "ip",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "host_names",
+                          "type": "STRING",
+                          "mode": "REPEATED"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "nfs_exports",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "entries",
+                      "type": "RECORD",
+                      "mode": "REPEATED",
+                      "fields": [
+                        {
+                          "name": "export_directory",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "hosts",
+                          "type": "STRING",
+                          "mode": "REPEATED"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "selinux_mode",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                }
+              ]
+            },
+            {
+              "name": "runtime",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "services",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "entries",
+                      "type": "RECORD",
+                      "mode": "REPEATED",
+                      "fields": [
+                        {
+                          "name": "service_name",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "state",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "start_mode",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "exe_path",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "cmdline",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "pid",
+                          "type": "INTEGER",
+                          "mode": "NULLABLE"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "processes",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "entries",
+                      "type": "RECORD",
+                      "mode": "REPEATED",
+                      "fields": [
+                        {
+                          "name": "pid",
+                          "type": "INTEGER",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "exe_path",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "cmdline",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "user",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "attributes",
+                          "type": "RECORD",
+                          "mode": "REPEATED",
+                          "fields": [
+                            {
+                              "name": "key",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "value",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "network",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "scan_time",
+                      "type": "TIMESTAMP",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "connections",
+                      "type": "RECORD",
+                      "mode": "NULLABLE",
+                      "fields": [
+                        {
+                          "name": "entries",
+                          "type": "RECORD",
+                          "mode": "REPEATED",
+                          "fields": [
+                            {
+                              "name": "protocol",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "local_ip_address",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "local_port",
+                              "type": "INTEGER",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "remote_ip_address",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "remote_port",
+                              "type": "INTEGER",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "state",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "pid",
+                              "type": "INTEGER",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "process_name",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "last_boot_time",
+                  "type": "TIMESTAMP",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "domain",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "machine_name",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "installed_apps",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "entries",
+                      "type": "RECORD",
+                      "mode": "REPEATED",
+                      "fields": [
+                        {
+                          "name": "application_name",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "vendor",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "install_time",
+                          "type": "TIMESTAMP",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "path",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "version",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "open_file_list",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "entries",
+                      "type": "RECORD",
+                      "mode": "REPEATED",
+                      "fields": [
+                        {
+                          "name": "command",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "user",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "file_type",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "file_path",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "network",
+          "type": "RECORD",
+          "mode": "NULLABLE",
+          "fields": [
+            {
+              "name": "primary_ip_address",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "public_ip_address",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "primary_mac_address",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "adapters",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "entries",
+                  "type": "RECORD",
+                  "mode": "REPEATED",
+                  "fields": [
+                    {
+                      "name": "adapter_type",
+                      "type": "STRING",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "mac_address",
+                      "type": "STRING",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "addresses",
+                      "type": "RECORD",
+                      "mode": "NULLABLE",
+                      "fields": [
+                        {
+                          "name": "entries",
+                          "type": "RECORD",
+                          "mode": "REPEATED",
+                          "fields": [
+                            {
+                              "name": "ip_address",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "subnet_mask",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "bcast",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "fqdn",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "assignment",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "disks",
+          "type": "RECORD",
+          "mode": "NULLABLE",
+          "fields": [
+            {
+              "name": "total_capacity_bytes",
+              "type": "INTEGER",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "total_free_bytes",
+              "type": "INTEGER",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "disks",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "entries",
+                  "type": "RECORD",
+                  "mode": "REPEATED",
+                  "fields": [
+                    {
+                      "name": "capacity_bytes",
+                      "type": "INTEGER",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "free_bytes",
+                      "type": "INTEGER",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "disk_label",
+                      "type": "STRING",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "disk_label_type",
+                      "type": "STRING",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "interface_type",
+                      "type": "STRING",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "partitions",
+                      "type": "RECORD",
+                      "mode": "NULLABLE",
+                      "fields": [
+                        {
+                          "name": "entries",
+                          "type": "RECORD",
+                          "mode": "REPEATED",
+                          "fields": [
+                            {
+                              "name": "type",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "file_system",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "mount_point",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "capacity_bytes",
+                              "type": "INTEGER",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "free_bytes",
+                              "type": "INTEGER",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "uuid",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "hw_address",
+                      "type": "STRING",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "vmware",
+                      "type": "RECORD",
+                      "mode": "NULLABLE",
+                      "fields": [
+                        {
+                          "name": "backing_type",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "shared",
+                          "type": "BOOLEAN",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "vmdk_mode",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "rdm_compatibility",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "platform",
+          "type": "RECORD",
+          "mode": "NULLABLE",
+          "fields": [
+            {
+              "name": "vmware_details",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "vcenter_version",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "esx_version",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "osid",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "vcenter_folder",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "vcenter_uri",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "vcenter_vm_id",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                }
+              ]
+            },
+            {
+              "name": "aws_ec2_details",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "machine_type_label",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "location",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                }
+              ]
+            },
+            {
+              "name": "azure_vm_details",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "machine_type_label",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "location",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "provisioning_state",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                }
+              ]
+            },
+            {
+              "name": "generic_details",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "location",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                }
+              ]
+            },
+            {
+              "name": "physical_details",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "location",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "insight_list",
+      "type": "RECORD",
+      "mode": "NULLABLE",
+      "fields": [
+        {
+          "name": "insights",
+          "type": "RECORD",
+          "mode": "REPEATED",
+          "fields": [
+            {
+              "name": "migration_insight",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "fit",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "fit_level",
+                      "type": "STRING",
+                      "mode": "NULLABLE"
+                    }
+                  ]
+                },
+                {
+                  "name": "compute_engine_target",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "shape",
+                      "type": "RECORD",
+                      "mode": "NULLABLE",
+                      "fields": [
+                        {
+                          "name": "memory_mb",
+                          "type": "INTEGER",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "physical_core_count",
+                          "type": "INTEGER",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "logical_core_count",
+                          "type": "INTEGER",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "series",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "machine_type",
+                          "type": "STRING",
+                          "mode": "NULLABLE"
+                        },
+                        {
+                          "name": "storage",
+                          "type": "RECORD",
+                          "mode": "REPEATED",
+                          "fields": [
+                            {
+                              "name": "type",
+                              "type": "STRING",
+                              "mode": "NULLABLE"
+                            },
+                            {
+                              "name": "size_gb",
+                              "type": "INTEGER",
+                              "mode": "NULLABLE"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "generic_insight",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "message_id",
+                  "type": "INTEGER",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "default_message",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "additional_information",
+                  "type": "STRING",
+                  "mode": "REPEATED"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "update_time",
+          "type": "TIMESTAMP",
+          "mode": "NULLABLE"
+        }
+      ]
+    },
+    {
+      "name": "performance_data",
+      "type": "RECORD",
+      "mode": "NULLABLE",
+      "fields": [
+        {
+          "name": "daily_resource_usage_aggregations",
+          "type": "RECORD",
+          "mode": "REPEATED",
+          "fields": [
+            {
+              "name": "date",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "year",
+                  "type": "INTEGER",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "month",
+                  "type": "INTEGER",
+                  "mode": "NULLABLE"
+                },
+                {
+                  "name": "day",
+                  "type": "INTEGER",
+                  "mode": "NULLABLE"
+                }
+              ]
+            },
+            {
+              "name": "cpu",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "utilization_percentage",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "average",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "median",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "nintey_fifth_percentile",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "peak",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "memory",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "utilization_percentage",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "average",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "median",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "nintey_fifth_percentile",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "peak",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "network",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "ingress_bps",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "average",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "median",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "nintey_fifth_percentile",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "peak",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    }
+                  ]
+                },
+                {
+                  "name": "egress_bps",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "average",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "median",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "nintey_fifth_percentile",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "peak",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "disk",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "iops",
+                  "type": "RECORD",
+                  "mode": "NULLABLE",
+                  "fields": [
+                    {
+                      "name": "average",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "median",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "nintey_fifth_percentile",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    },
+                    {
+                      "name": "peak",
+                      "type": "FLOAT",
+                      "mode": "NULLABLE"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "sources",
+      "type": "STRING",
+      "mode": "REPEATED"
+    },
+    {
+      "name": "assigned_groups",
+      "type": "STRING",
+      "mode": "REPEATED"
+    }
+  ],
+  "group_table": [
+    {
+      "name": "name",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "create_time",
+      "type": "TIMESTAMP",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "update_time",
+      "type": "TIMESTAMP",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "labels",
+      "type": "RECORD",
+      "mode": "REPEATED",
+      "fields": [
+        {
+          "name": "key",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "value",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        }
+      ]
+    },
+    {
+      "name": "display_name",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "description",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    }
+  ],
+  "preference_set_table": [
+    {
+      "name": "name",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "create_time",
+      "type": "TIMESTAMP",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "update_time",
+      "type": "TIMESTAMP",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "display_name",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "description",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "virtual_machine_preferences",
+      "type": "RECORD",
+      "mode": "NULLABLE",
+      "fields": [
+        {
+          "name": "target_product",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "region_preferences",
+          "type": "RECORD",
+          "mode": "NULLABLE",
+          "fields": [
+            {
+              "name": "preferred_regions",
+              "type": "STRING",
+              "mode": "REPEATED"
+            }
+          ]
+        },
+        {
+          "name": "commitment_plan",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "sizing_optimization_strategy",
+          "type": "STRING",
+          "mode": "NULLABLE"
+        },
+        {
+          "name": "compute_engine_preferences",
+          "type": "RECORD",
+          "mode": "NULLABLE",
+          "fields": [
+            {
+              "name": "machine_preferences",
+              "type": "RECORD",
+              "mode": "NULLABLE",
+              "fields": [
+                {
+                  "name": "allowed_machine_series",
+                  "type": "RECORD",
+                  "mode": "REPEATED",
+                  "fields": [
+                    {
+                      "name": "code",
+                      "type": "STRING",
+                      "mode": "NULLABLE"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "license_type",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            }
+          ]
+        },
+        {
+          "name": "vmware_engine_preferences",
+          "type": "RECORD",
+          "mode": "NULLABLE",
+          "fields": [
+            {
+              "name": "cpu_overcommit_ratio",
+              "type": "FLOAT",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "memory_overcommit_ratio",
+              "type": "FLOAT",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "storage_deduplication_compression_ratio",
+              "type": "FLOAT",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "commitment_plan",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            }
+          ]
+        },
+        {
+          "name": "sole_tenancy_preferences",
+          "type": "RECORD",
+          "mode": "NULLABLE",
+          "fields": [
+            {
+              "name": "cpu_overcommit_ratio",
+              "type": "FLOAT",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "host_maintenance_policy",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "commitment_plan",
+              "type": "STRING",
+              "mode": "NULLABLE"
+            },
+            {
+              "name": "node_types",
+              "type": "RECORD",
+              "mode": "REPEATED",
+              "fields": [
+                {
+                  "name": "node_name",
+                  "type": "STRING",
+                  "mode": "NULLABLE"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
   ]
- }
-]}
+}

--- a/tools/mc2bq/pkg/schema/schema_test.go
+++ b/tools/mc2bq/pkg/schema/schema_test.go
@@ -32,107 +32,49 @@ import (
 // The tests uses a golden output file.
 // To update it run: go test -test.generate-golden-files $PWD
 func TestObjectSerializer(t *testing.T) {
-	type TestInnerStruct struct {
-		FieldA string
-		FieldB int
-	}
-	innerStructSchema := bigquery.Schema{
-		{Name: "field_a", Type: bigquery.StringFieldType},
-		{Name: "field_b", Type: bigquery.IntegerFieldType},
-	}
-	type TestStruct struct {
-		IntScalar       int
-		StringScalar    string
-		BoolScalar      bool
-		Float32Scalar   float32
-		Float64Scalar   float64
-		IntArray        []int
-		Timestamp       timestamppb.Timestamp
-		TimestampPtr    *timestamppb.Timestamp
-		DynamicMap      map[string]string
-		Record          TestInnerStruct
-		RecordPtr       *TestInnerStruct
-		NullPtr         *TestInnerStruct
-		RecordArray     []*TestInnerStruct
-		RecordMap       map[string]*TestInnerStruct
-		DeprecatedField string
-		Enum            migrationcenterpb.CommitmentPlan
-	}
-	schema := bigquery.Schema{
-		{Name: "int_scalar", Type: bigquery.IntegerFieldType},
-		{Name: "string_scalar", Type: bigquery.StringFieldType},
-		{Name: "bool_scalar", Type: bigquery.BooleanFieldType},
-		{Name: "float32_scalar", Type: bigquery.FloatFieldType},
-		{Name: "float64_scalar", Type: bigquery.FloatFieldType},
-		{Name: "int_array", Type: bigquery.IntegerFieldType, Repeated: true},
-		{Name: "timestamp", Type: bigquery.TimestampFieldType},
-		{Name: "timestamp_ptr", Type: bigquery.TimestampFieldType},
-		{Name: "dynamic_map", Type: bigquery.RecordFieldType, Repeated: true, Schema: bigquery.Schema{
-			{Name: "key", Type: bigquery.StringFieldType},
-			{Name: "value", Type: bigquery.StringFieldType},
-		}},
-		{Name: "record", Type: bigquery.RecordFieldType, Schema: innerStructSchema},
-		{Name: "record_ptr", Type: bigquery.RecordFieldType, Schema: innerStructSchema},
-		{Name: "record_array", Type: bigquery.RecordFieldType, Schema: innerStructSchema, Repeated: true},
-		{Name: "record_map", Type: bigquery.RecordFieldType, Repeated: true, Schema: bigquery.Schema{
-			{Name: "key", Type: bigquery.StringFieldType},
-			{Name: "value", Type: bigquery.RecordFieldType, Schema: innerStructSchema},
-		}},
-		{Name: "enum", Type: bigquery.StringFieldType},
-		// DeprecatedField doesn't appear in the schema as it has been deprecated
-	}
+	schema := EmbeddedSchema.AssetTable
 	// This ensures that we are testing all the field types that exist in the schema
 	ensureTypeSetCoverage(t, schema)
 
-	obj := &TestStruct{
-		IntScalar:       3,
-		StringScalar:    "foo",
-		BoolScalar:      false,
-		IntArray:        []int{1, 2, 3},
-		Float32Scalar:   0.32,
-		Float64Scalar:   0.64,
-		DynamicMap:      map[string]string{"foo": "bar", "fizz": "buzz"},
-		Timestamp:       *timestamppb.New(time.Unix(1337, 1773)),
-		TimestampPtr:    timestamppb.New(time.Unix(1337, 1773)),
-		Record:          TestInnerStruct{FieldA: "test", FieldB: 10},
-		RecordPtr:       &TestInnerStruct{FieldA: "test", FieldB: 10},
-		NullPtr:         nil,
-		RecordArray:     []*TestInnerStruct{{FieldA: "1", FieldB: 1}, {FieldA: "2", FieldB: 2}},
-		RecordMap:       map[string]*TestInnerStruct{"key": {FieldA: "value"}},
-		DeprecatedField: "I should not be in the result JSON",
-		Enum:            1,
+	asset := migrationcenterpb.Asset{
+		Name:       "foo",                              // string
+		CreateTime: timestamppb.New(time.Unix(10, 10)), // timestamp
+		Labels: map[string]string{ // map
+			"key":  "value",
+			"key2": "value2",
+		},
+		InsightList: &migrationcenterpb.InsightList{
+			Insights: []*migrationcenterpb.Insight{
+				{
+					Insight: &migrationcenterpb.Insight_MigrationInsight{ // one_of
+						MigrationInsight: &migrationcenterpb.MigrationInsight{
+							Fit: &migrationcenterpb.FitDescriptor{
+								FitLevel: migrationcenterpb.FitDescriptor_FIT, // enum
+							},
+						},
+					},
+				},
+			},
+		},
+		AssetDetails: &migrationcenterpb.Asset_MachineDetails{
+			MachineDetails: &migrationcenterpb.MachineDetails{
+				MachineName: "foo",
+				MemoryMb:    10, // integer
+			},
+		},
 	}
 
-	got, err := SerializeObjectToBigQuery(obj, "object", schema)
+	serializer := NewSerializer[*migrationcenterpb.Asset]("asset", schema)
+
+	got, err := serializer(&asset)
 	if err != nil {
-		t.Fatalf("SerializeObjectToBigQuery(%+v, ...): unexpected error: %v", obj, err)
+		t.Fatalf("SerializeObjectToBigQuery(%+v, ...): unexpected error: %v", &asset, err)
 	}
 
 	// We do this so that the diff is more human readable
 	got = prettyPrintJSON(got)
 	if diff := golden.Compare(t, "exporter.json", string(got)); diff != "" {
-		t.Fatalf("SerializeObjectToBigQuery(%+v, ...): mismatch (-want, +got):\n%s", obj, diff)
-	}
-}
-
-func TestInvalidTimestamp(t *testing.T) {
-	type TestStruct struct {
-		Timestamp int
-	}
-	schema := bigquery.Schema{
-		{Name: "timestamp", Type: bigquery.TimestampFieldType},
-	}
-	obj := &TestStruct{
-		Timestamp: 10,
-	}
-
-	got, err := SerializeObjectToBigQuery(obj, "object", schema)
-	if err == nil {
-		t.Fatalf("SerializeObjectToBigQuery(%+v, ...): succeeded unexpectedly", obj)
-	}
-
-	if diff := cmp.Diff([]uint8(nil), got); diff != "" {
-		t.Fatalf("SerializeObjectToBigQuery(%+v, ...): mismatch (-want, +got):\n%s", obj, diff)
+		t.Fatalf("SerializeObjectToBigQuery(%+v, ...): mismatch (-want, +got):\n%s", &asset, diff)
 	}
 }
 

--- a/tools/mc2bq/pkg/schema/testdata/exporter.json.golden
+++ b/tools/mc2bq/pkg/schema/testdata/exporter.json.golden
@@ -1,52 +1,32 @@
 {
-  "bool_scalar": false,
-  "dynamic_map": [
-    {
-      "key": "fizz",
-      "value": "buzz"
-    },
-    {
-      "key": "foo",
-      "value": "bar"
-    }
-  ],
-  "enum": "COMMITMENT_PLAN_NONE",
-  "float32_scalar": 0.32,
-  "float64_scalar": 0.64,
-  "int_array": [
-    1,
-    2,
-    3
-  ],
-  "int_scalar": 3,
-  "record": {
-    "field_a": "test",
-    "field_b": 10
+  "create_time": "1970-01-01T00:00:10Z",
+  "insight_list": {
+    "insights": [
+      {
+        "migration_insight": {
+          "fit": {
+            "fit_level": "FIT"
+          }
+        }
+      }
+    ]
   },
-  "record_array": [
-    {
-      "field_a": "1",
-      "field_b": 1
-    },
-    {
-      "field_a": "2",
-      "field_b": 2
-    }
-  ],
-  "record_map": [
+  "labels": [
     {
       "key": "key",
-      "value": {
-        "field_a": "value",
-        "field_b": 0
-      }
+      "value": "value"
+    },
+    {
+      "key": "key2",
+      "value": "value2"
     }
   ],
-  "record_ptr": {
-    "field_a": "test",
-    "field_b": 10
+  "machine_details": {
+    "core_count": 0,
+    "machine_name": "foo",
+    "memory_mb": 10,
+    "power_state": "POWER_STATE_UNSPECIFIED",
+    "uuid": ""
   },
-  "string_scalar": "foo",
-  "timestamp": "1970-01-01T00:22:17Z",
-  "timestamp_ptr": "1970-01-01T00:22:17Z"
+  "name": "foo"
 }


### PR DESCRIPTION
This is used instead of regular Go relection because it is harder
to map it to the table schema. The protobuf is the canonical
representation making converison easier.
