### PR TITLE
Adding Client Options to the Export function

### DIFF
--- a/tools/mc2bq/pkg/export/export.go
+++ b/tools/mc2bq/pkg/export/export.go
@@ -49,6 +49,7 @@ type Params struct {
 	DatasetID       string
 	TablePrefix     string
 	Schema          *exporterschema.ExporterSchema
+	MCOptions       []option.ClientOption
 	UserAgentSuffix string
 }
 
@@ -69,8 +70,11 @@ func buildClientOptions(params *Params) []option.ClientOption {
 		userAgent += "_" + params.UserAgentSuffix
 	}
 	opts = append(opts, option.WithUserAgent(userAgent))
-
 	return opts
+}
+
+func buildMCClientOptions(params *Params) []option.ClientOption {
+	return append(buildClientOptions(params), params.MCOptions...)
 }
 
 func newExportTask(ctx context.Context, dataset *bigquery.Dataset, params *Params, src mcutil.ObjectSource, tableSuffix string, objectCount uint64) func() error {
@@ -121,7 +125,7 @@ func newExportTask(ctx context.Context, dataset *bigquery.Dataset, params *Param
 
 // MCFactory creates a an MC implementation accorording to params
 func MCFactory(ctx context.Context, params *Params) (mcutil.MC, error) {
-	svc, err := migrationcenter.NewClient(ctx, buildClientOptions(params)...)
+	svc, err := migrationcenter.NewClient(ctx, buildMCClientOptions(params)...)
 	if err != nil {
 		return nil, fmt.Errorf("create migration center client: %w", err)
 	}


### PR DESCRIPTION
Adding Client Options to the Export function. This will enable working with different endpoints and allow for easier testing. 