### PR TITLE
security: Fix Command Injection in c2c-report.py and harden Sheets imports against Formula Injection

### DIFF
--- a/tools/c2c-report/python/c2c-report.py
+++ b/tools/c2c-report/python/c2c-report.py
@@ -34,6 +34,7 @@ import argparse
 import time
 import os
 import json
+from typing import Any
 
 version = "v0.2"
 datetime = str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
@@ -52,6 +53,31 @@ f.close()
 
 default_mc_looker_template_id = "421c8150-e7ad-4190-b044-6a18ecdbd391"
 default_cur_looker_template_id = "c4e0ccbc-907a-4bc4-85f1-1711ee47c345"
+
+
+def escape_csv_value(val: Any) -> Any:
+    """Escapes a value for CSV/Sheets to prevent formula injection.
+
+    If the value is a string and starts with a formula triggering character
+    (=, +, -, @, tab, carriage return), prepends a single quote, unless
+    the value is a valid number (to preserve negative/positive numbers).
+    """
+    if not isinstance(val, str):
+        return val
+    if not val:
+        return val
+
+    # If it is a valid number, do not escape it (preserves negative/positive numbers)
+    try:
+        float(val)
+        return val
+    except ValueError:
+        pass
+
+    trigger_chars = ("=", "+", "-", "@", "\t", "\r")
+    if val.startswith(trigger_chars):
+        return "'" + val
+    return val
 
 
 # Check if we should use List Price instead of Actual Cost
@@ -2078,10 +2104,12 @@ def import_mc_data_sheets(mc_reports_directory, spreadsheet, credentials):
             print(f"\t{file}...")
             # print(list(csv.reader(open(file_fullpath))))
             worksheet = sh.add_worksheet(title=sheet_name, rows=100, cols=30)
+            csv_content = list(csv.reader(open(file_fullpath)))
+            sanitized_content = [[escape_csv_value(cell) for cell in row] for row in csv_content]
             sh.values_update(
                 sheet_name,
                 params={'valueInputOption': 'USER_ENTERED'},
-                body={'values': list(csv.reader(open(file_fullpath)))})
+                body={'values': sanitized_content})
 
             response = sh.batch_update(generate_protect_sheet_request(worksheet._properties['sheetId']))
 

--- a/tools/c2c-report/python/c2c-report.py
+++ b/tools/c2c-report/python/c2c-report.py
@@ -2167,7 +2167,7 @@ def import_mc_into_bq(mc_reports_directory, gcp_project_id, bq_dataset_name, bq_
         exit()
 
     # Create BQ dataset
-    client = bigquery.Client()
+    client = bigquery.Client(project=gcp_project_id)
     dataset_id = f"{gcp_project_id}.{bq_dataset_name}"
 
     # Construct a full Dataset object to send to the API.
@@ -2195,7 +2195,6 @@ def import_mc_into_bq(mc_reports_directory, gcp_project_id, bq_dataset_name, bq_
             bq_table_name = (f"{bq_table_prefix}{file.replace('.csv', '')}")
             table_id = (f"{gcp_project_id}.{bq_dataset_name}.{bq_table_name}")
             print(f"Importing {os.path.basename(file_fullpath)} into BQ Table: {table_id}")
-            set_gcp_project = f"gcloud config set project {gcp_project_id} >/dev/null 2>&1"
 
             schema = ""
             for column in mc_column_names[file].keys():
@@ -2203,10 +2202,6 @@ def import_mc_into_bq(mc_reports_directory, gcp_project_id, bq_dataset_name, bq_
 
             # Remove last comma
             schema = schema[:-1]
-            try:
-                os.system(set_gcp_project)
-            except Exception as e:
-                print(f"error: {e}")
 
             # file_fullpath already correctly points to the actual file path
 
@@ -2303,7 +2298,7 @@ def import_cur_into_bq(mc_reports_directory, gcp_project_id, bq_dataset_name, bq
                      os.path.isfile(os.path.join(mc_reports_directory, f))]
 
     # Create BQ dataset
-    client = bigquery.Client()
+    client = bigquery.Client(project=gcp_project_id)
     dataset_id = f"{gcp_project_id}.{bq_dataset_name}"
 
     # Construct a full Dataset object to send to the API.
@@ -2333,7 +2328,6 @@ def import_cur_into_bq(mc_reports_directory, gcp_project_id, bq_dataset_name, bq
             num_lines = sum(1 for _ in f)
         if num_lines > 1:
             print(f"Importing {file} into BQ Table: {table_id}")
-            set_gcp_project = f"gcloud config set project {gcp_project_id} >/dev/null 2>&1"
 
             # schema = ""
             # for column in mc_column_names[file].keys():
@@ -2341,10 +2335,7 @@ def import_cur_into_bq(mc_reports_directory, gcp_project_id, bq_dataset_name, bq
             #
             # # Remove last comma
             # schema = schema[:-1]
-            try:
-                os.system(set_gcp_project)
-            except Exception as e:
-                print(f"error: {e}")
+
 
             # if file.endswith(".csv"):
             file_fullpath = (f"{mc_reports_directory}{file}")

--- a/tools/c2c-report/python/c2c-report.py
+++ b/tools/c2c-report/python/c2c-report.py
@@ -67,7 +67,8 @@ def escape_csv_value(val: Any) -> Any:
     if not val:
         return val
 
-    # If it is a valid number, do not escape it (preserves negative/positive numbers)
+    # If it is a valid number, do not escape it (preserves negative/positive
+    # numbers).
     try:
         float(val)
         return val
@@ -2105,7 +2106,9 @@ def import_mc_data_sheets(mc_reports_directory, spreadsheet, credentials):
             # print(list(csv.reader(open(file_fullpath))))
             worksheet = sh.add_worksheet(title=sheet_name, rows=100, cols=30)
             csv_content = list(csv.reader(open(file_fullpath)))
-            sanitized_content = [[escape_csv_value(cell) for cell in row] for row in csv_content]
+            sanitized_content = [
+                [escape_csv_value(cell) for cell in row] for row in csv_content
+            ]
             sh.values_update(
                 sheet_name,
                 params={'valueInputOption': 'USER_ENTERED'},

--- a/tools/calcctl-to-sheets/python/calcctl-to-sheets.py
+++ b/tools/calcctl-to-sheets/python/calcctl-to-sheets.py
@@ -8,6 +8,32 @@ import argparse
 import yaml
 from gspread_helper import load_spreadsheet, create_spreadsheet_from_template
 import re
+from typing import Any
+
+def escape_csv_value(val: Any) -> Any:
+    """Escapes a value for CSV/Sheets to prevent formula injection.
+
+    If the value is a string and starts with a formula triggering character
+    (=, +, -, @, tab, carriage return), prepends a single quote, unless
+    the value is a valid number (to preserve negative/positive numbers).
+    """
+    if not isinstance(val, str):
+        return val
+    if not val:
+        return val
+
+    # If it is a valid number, do not escape it (preserves negative/positive numbers)
+    try:
+        float(val)
+        return val
+    except ValueError:
+        pass
+
+    trigger_chars = ("=", "+", "-", "@", "\t", "\r")
+    if val.startswith(trigger_chars):
+        return "'" + val
+    return val
+
 
 calcctl_names = {
     "mapped": "Mapped Data",
@@ -35,6 +61,7 @@ def add_inferred_discounts_to_summary(reports_dir, spreadsheet):
         return
 
     general_discount = inferred_discounts.get('general', 'Could not Infer')
+    general_discount = escape_csv_value(general_discount)
     print(f"General Discount from source files: {general_discount}")
 
     try:
@@ -48,7 +75,7 @@ def add_inferred_discounts_to_summary(reports_dir, spreadsheet):
             print("Adding inferred discounts by product...")
             updates_to_perform.append({'range': 'B15', 'values': [["Inferred Discount per Product"]]})
 
-            product_discounts_data = list(average_by_product.items())
+            product_discounts_data = [(escape_csv_value(k), escape_csv_value(v)) for k, v in average_by_product.items()]
             if product_discounts_data:
                 start_row = 16
                 end_row = start_row + len(product_discounts_data) - 1
@@ -118,8 +145,8 @@ def load_assumptions(reports_dir, spreadsheet):
     current_row = 1
 
     for section, items in assumptions.items():
-        # Add section title
         section_title = section.replace('_', ' ').title()
+        section_title = escape_csv_value(section_title)
         all_values.append([section_title])
         formats_to_apply.append({
             'range': f'A{current_row}',
@@ -169,10 +196,13 @@ def import_calcctl_data(calcctl_reports_directory, sh):
                 sheet_name = calcctl_names[file_name]
                 with open(file_fullpath, 'r', encoding='utf-8') as f_csv:
                     csv_content = list(csv.reader(f_csv))
+                
+                sanitized_content = [[escape_csv_value(cell) for cell in row] for row in csv_content]
+                
                 sh.values_update(
                     sheet_name,
                     params={'valueInputOption': 'USER_ENTERED'},
-                    body={'values': csv_content})
+                    body={'values': sanitized_content})
 
 
 # Parse CLI Arguments

--- a/tools/calcctl-to-sheets/python/calcctl-to-sheets.py
+++ b/tools/calcctl-to-sheets/python/calcctl-to-sheets.py
@@ -22,7 +22,8 @@ def escape_csv_value(val: Any) -> Any:
     if not val:
         return val
 
-    # If it is a valid number, do not escape it (preserves negative/positive numbers)
+    # If it is a valid number, do not escape it (preserves negative/positive
+    # numbers).
     try:
         float(val)
         return val
@@ -197,7 +198,10 @@ def import_calcctl_data(calcctl_reports_directory, sh):
                 with open(file_fullpath, 'r', encoding='utf-8') as f_csv:
                     csv_content = list(csv.reader(f_csv))
                 
-                sanitized_content = [[escape_csv_value(cell) for cell in row] for row in csv_content]
+                sanitized_content = [
+                    [escape_csv_value(cell) for cell in row]
+                    for row in csv_content
+                ]
                 
                 sh.values_update(
                     sheet_name,


### PR DESCRIPTION
### Summary of Changes

This Pull Request addresses two classes of security vulnerabilities across the import utilities:
1.  **Command Injection** in `c2c-report.py`.
2.  **Formula Injection (CSV Injection)** in both `c2c-report.py` and `calcctl-to-sheets.py`.

All changes have been successfully implemented using native, secure Python configurations and empirically verified regression-free via simulated local testing.

---

### 1. Fix: Command Injection in `c2c-report.py`

*   **Vulnerability:** The script parses a GCP Project ID from the `-i` connection string and passes it directly into a shell command executing `gcloud config set project` via `os.system()` without any validation or escaping, allowing arbitrary command execution (e.g. via `;` chained commands).
*   **Resolution:** 
    *   Removed the unsafe and redundant `os.system` shell subprocess call entirely.
    *   Configured the Python `bigquery.Client` constructor to securely target the intended project ID using native configuration: `bigquery.Client(project=gcp_project_id)`. This utilizes the client library's built-in parameter validation and is the standard SDK approach.

---

### 2. Fix: Formula Injection (CSV Injection) in `c2c-report.py` & `calcctl-to-sheets.py`

*   **Vulnerability:** When importing raw report data directly into standard Google Sheets (without BigQuery), both scripts use the `USER_ENTERED` option. This causes Google Sheets to automatically parse and execute any cell starting with formula trigger characters (`=`, `+`, `-`, `@`, `\t`, `\r`) as a live formula, which poses a serious data exfiltration risk if attackers manipulate resource descriptions in the source cloud report.
*   **Resolution:**
    *   Ported the defensive `escape_csv_value` helper (which was partially developed as local modifications in `calcctl-to-sheets.py` but never committed upstream) to both scripts.
    *   This helper automatically detects formula-triggering characters in cells and prepends a single quote `'` (standard Sheets force-text prefix) to prevent formula parsing, while explicitly preserving valid numbers (positives, negatives, decimals) so that dynamic dashboard calculations, Pivot Tables, and charts continue to work correctly.
    *   Applied the sanitization across all raw CSV-to-Sheets import pathways in both the AWS/MC and Azure pipelines.

---

### 3. Local Verification & Regression Status

*   Both pipelines were exhaustively verified locally under a custom test harness using Python's `unittest.mock` to bypass backend API credential locks.
*   **Command Injection Exploit Verification:** Confirmed that the original script successfully executes chained injection payloads (e.g. `touch /tmp/c2c_inject_test`), while the modified script safely blocks the shell and exits gracefully on the BQ API call.
*   **Regression Verification:** Verified that both `c2c-report.py` (Sheets-only pipeline) and `calcctl-to-sheets.py` (Azure import pipeline) run to full completion under mock data without any crashes, successfully generating sheet layouts, applying conditional formatting, and running complex dynamic calculations (such as AWS Total Spend verification) without regressions.

---
