### PR TITLE
Deprecate mconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is broken up into:
   * [c2c-report](/tools/c2c-report) - Migration Center C2C Data Import - Creates Sheets, Looker & BQ resources.
   * [calcctl-to-sheets](/tools/calcctl-to-sheets) - Migration Center C2C - Creates Sheets based on Calcctl output.  
   * [mc2bq](/tools/mc2bq) - Migration Center exported to BigQuery.
-  * [mconnect](/tools/mconnect) - Merges information from Google Cloud Migration Center and static code analysis of applications performed by CAST Software to BigQuery for data analysis in Looker Studio.
+  * [mconnect](/tools/mconnect) - **(DEPRECATED)** Merges information from Google Cloud Migration Center and static code analysis of applications performed by CAST Software to BigQuery for data analysis in Looker Studio.
 
 ## Contributing
 

--- a/tools/mconnect/README.md
+++ b/tools/mconnect/README.md
@@ -1,5 +1,9 @@
 # MConnect
 
+> [!WARNING]
+> **MConnect is deprecated and no longer supported.**
+> This tool is no longer actively maintained. For application discovery and assessment, please use Google Cloud Migration Center directly.
+
 A command line interface used to export and merge information from Migration Center and CAST to BigQuery, which allows you to perform data analysis in Looker Studio.
 
 ## Before you begin


### PR DESCRIPTION
This PR marks the mconnect tool as deprecated in the READMEs, as part of the MC Handover process.